### PR TITLE
Fix crashes due to new language 8

### DIFF
--- a/pysaintcoinach/ex/header.py
+++ b/pysaintcoinach/ex/header.py
@@ -1,11 +1,13 @@
 from typing import Iterable as IterableT, Sequence as SequenceT
 from struct import unpack_from
+import logging
 
 from .language import Language
 from .column import Column
 from ..file import File
 from .. import ex
 
+logger = logging.getLogger(__name__)
 
 class Header(object):
 
@@ -16,7 +18,9 @@ class Header(object):
                     4: Language.french,
                     5: Language.chinese_simplified,
                     6: Language.chinese_traditional,
-                    7: Language.korean}
+                    7: Language.korean,
+                    8: Language.traditional_chinese,
+    }
 
     @property
     def collection(self) -> 'ex.ExCollection':
@@ -131,9 +135,16 @@ class Header(object):
         count, = unpack_from(">H", buffer, COUNT_OFFSET)
         self.__available_languages = []
         for i in range(count):
-            lang = self.LANGUAGE_MAP[buffer[position]]
+            code = buffer[position]
+            lang = self.LANGUAGE_MAP.get(code)
+            if lang is None:
+                logger.warning("Unknown language code %u. Will set unsupported language.", code)
+                lang = Language.unsupported
+
             position += LENGTH
             if lang != Language.unsupported:
                 self.__available_languages += [lang]
 
         return
+
+

--- a/pysaintcoinach/ex/language.py
+++ b/pysaintcoinach/ex/language.py
@@ -10,6 +10,7 @@ class Language(Enum):
     chinese_simplified = "chs"
     chinese_traditional = "cht"
     korean = "ko"
+    traditional_chinese = "tc"
     unsupported = "?"
 
     def get_code(self):


### PR DESCRIPTION
## Changes

- adds new language "8" as Traditional chinese. Was confirmed that that is what it is for example from: https://github.com/NotAdam/Lumina/pull/120 where they fixed the same thing. The language was added in 7.2 and "replaces" language 6 "probably".
Also an issue for the same is open in main SaintCoinch repo: https://github.com/xivapi/SaintCoinach/issues/233

it seems like `cht` is used for none-chinese country clients to use chinese while in china itself it's `tc` or something similar.

- Also added a small thing at the end of headers.py that will make sure in the future it doesn't break due to new languages but will just log a warning.